### PR TITLE
fix: crash when tapping profile from notification post view

### DIFF
--- a/app/components/Feed.js
+++ b/app/components/Feed.js
@@ -502,7 +502,7 @@ const Feed = ({ route, navigation }) => {
         </TouchableOpacity>
   
       </View>
-      <NormalItemTile item={focusedItem} visitingUserId={userKey} navigation={navigation} showComments={true} onBlockUser={onBlockUserLocal}/>
+      <NormalItemTile item={focusedItem} userKey={userKey} visitingUserId={userKey} navigation={navigation} showComments={true} setFeedView={setFeedView} onBlockUser={onBlockUserLocal}/>
       </View>
     );
   }
@@ -524,7 +524,7 @@ const Feed = ({ route, navigation }) => {
             <Ionicons name="arrow-back" size={30} color="black" />
           </TouchableOpacity>
         </View>
-        <NormalItemTile item={itemInfo} visitingUserId={userKey} navigation={navigation} editMode={false} showComments={true} setFeedView={onBackPress} individualSpotifyAccessToken={individualSpotifyAccessToken} promptAsync={promptAsync} onBlockUser={onBlockUserLocal}/>
+        <NormalItemTile item={itemInfo} userKey={userKey} visitingUserId={userKey} navigation={navigation} editMode={false} showComments={true} setFeedView={onBackPress} individualSpotifyAccessToken={individualSpotifyAccessToken} promptAsync={promptAsync} onBlockUser={onBlockUserLocal}/>
       </View>
     );
   }


### PR DESCRIPTION
Fixes #60

## Root cause

When tapping a notification with a post link, `onItemPress` sets `focusedItem` and renders `NormalItemTile` without two required props:

- **`userKey`** — used to check `userKey === item.user_id` to decide whether to navigate to the current user's own Profile or call `setFeedView` for another user's profile. Without it the check always evaluates `undefined === userId` → `false`, so even tapping your own avatar takes the wrong branch.
- **`setFeedView`** — the function called when navigating to another user's profile. Without it, any avatar tap crashes with `setFeedView is not a function (it is undefined)`.

The same `userKey` omission existed in the `itemInfo` view (post opened via feed tap).

## Fix

Add `userKey={userKey}` and `setFeedView={setFeedView}` to the `focusedItem` NormalItemTile render, and `userKey={userKey}` to the `itemInfo` render.

## Test plan
- [ ] Open notifications → tap a notification that links to a post
- [ ] From that post, tap the author's avatar (someone you follow) → should navigate to their profile
- [ ] From that post, tap your own avatar → should navigate to your own Profile tab without crashing
🤖 Generated with [Claude Code](https://claude.com/claude-code)