### PR TITLE
fix: keyboard covers comment input and feed crash on tab switch

### DIFF
--- a/app/components/CommentsBottomSheet.js
+++ b/app/components/CommentsBottomSheet.js
@@ -188,15 +188,17 @@ const CommentsBottomSheet = ({
       animationType="slide"
       onRequestClose={onClose}
     >
-      <View style={styles.container}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        style={styles.container}
+      >
         {/* Backdrop */}
         <TouchableWithoutFeedback onPress={onClose}>
           <View style={styles.overlay} />
         </TouchableWithoutFeedback>
 
         {/* Modal Content */}
-        <KeyboardAvoidingView
-          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        <View
           style={styles.modalContent}
         >
           {/* Drag Handle */}
@@ -305,8 +307,8 @@ const CommentsBottomSheet = ({
               />
             </TouchableOpacity>
           </View>
-        </KeyboardAvoidingView>
-      </View>
+        </View>
+      </KeyboardAvoidingView>
     </Modal>
   );
 };
@@ -314,6 +316,7 @@ const CommentsBottomSheet = ({
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    justifyContent: 'flex-end',
   },
   overlay: {
     flex: 1,
@@ -323,7 +326,8 @@ const styles = StyleSheet.create({
     backgroundColor: 'white',
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,
-    height: '50%',
+    maxHeight: '85%',
+    minHeight: '40%',
   },
   dragHandle: {
     width: 40,

--- a/app/components/Feed.js
+++ b/app/components/Feed.js
@@ -622,8 +622,8 @@ const Feed = ({ route, navigation }) => {
             feedType === 'Top Posts' && listData && listData[topPostsTime]
               ? listData[topPostsTime].slice(0, numFeedItems)
               : feedType === 'For You'
-                ? listData
-                : listData.slice(0, numFeedItems)
+                ? (Array.isArray(listData) ? listData : [])
+                : (Array.isArray(listData) ? listData.slice(0, numFeedItems) : [])
           }
           renderItem={renderFeedItem}
           keyExtractor={keyExtractor}


### PR DESCRIPTION
## Summary
- **Keyboard fix**: `KeyboardAvoidingView` now wraps the entire modal screen instead of just the white panel. When the keyboard opens, the whole bottom sheet is pushed above it so the comment input stays visible.
- **Height fix**: Modal panel now uses `maxHeight: 85% / minHeight: 40%` instead of a fixed `height: 50%`, so it can resize when the keyboard is open.
- **Feed crash fix**: Added `Array.isArray(listData)` guard before calling `.slice()` in the feed list. Previously the app crashed when switching tabs while `listData` was still an object (Top Posts format) instead of an array.

## Test plan
- [ ] Open comments on any post → tap the comment input → keyboard should push the panel up, input remains visible
- [ ] Try replying to a comment with the keyboard open — reply indicator and input should both be visible
- [ ] Switch between Top Posts / For You / Following tabs rapidly — no crash should occur
- [ ] Dismiss keyboard by tapping the backdrop — panel returns to normal height

🤖 Generated with [Claude Code](https://claude.com/claude-code)