### PR TITLE
perf: reduce scroll jank in Feed, Profile, and CategoryList

### DIFF
--- a/app/components/CategoryList.js
+++ b/app/components/CategoryList.js
@@ -652,7 +652,7 @@ const CategoryList = ({ focusedCategory, focusedList, onBackPress, focusedCatego
             }, 100);
           }}
           ItemSeparatorComponent={() => <View style={{ height: 1, backgroundColor: '#e0e0e0' }} />}
-          windowSize={5}
+          windowSize={21}
           maxToRenderPerBatch={3}
           initialNumToRender={3}
           removeClippedSubviews={true}

--- a/app/components/Feed.js
+++ b/app/components/Feed.js
@@ -629,7 +629,7 @@ const Feed = ({ route, navigation }) => {
           keyExtractor={keyExtractor}
           removeClippedSubviews={true}
           maxToRenderPerBatch={10}
-          windowSize={5}
+          windowSize={21}
           initialNumToRender={10}
           numColumns={1}
           key={"single-column"}

--- a/app/components/Profile.js
+++ b/app/components/Profile.js
@@ -492,7 +492,7 @@ const Profile = ({ route, navigation }) => {
                 refreshProfile();
               }
             }}
-            scrollEventThrottle={1} // This ensures the scroll position is updated frequently
+            scrollEventThrottle={16}
           >
             {!visitingUserId ? (
               <View style={{ flexDirection: 'row', marginTop: 10, alignItems: 'center', width: '100%', paddingHorizontal: 20 }}>


### PR DESCRIPTION
## Summary
- Increase `windowSize` from 5 → 21 on FlatList in `Feed.js` and `CategoryList.js` so fast flings don't unmount/remount items mid-scroll
- Reduce `scrollEventThrottle` from 1 → 16 on Profile's ScrollView to stop flooding the JS thread with per-pixel scroll events

## Test plan
- [ ] Fast-fling scroll the Feed tab — should be smooth with no rubberbanding
- [ ] Tap into someone's category list and fast-scroll through items — should be smooth
- [ ] Pull-to-refresh on Profile still works correctly
- [ ] Profile scroll still feels responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)