### PR TITLE
feat: rerank button on list entries + fix post-rerank navigation

### DIFF
--- a/app/components/Add.js
+++ b/app/components/Add.js
@@ -759,8 +759,12 @@ const Add = ({ route, navigation }) => {
   }
 
   const onContinuePress = () => {
+    const wasRerank = !!rerankItemKey;
     resetToDefaultAddState();
     getUserCategories();
+    if (wasRerank) {
+      navigation.goBack();
+    }
   }
 
   if (addView === 'addingItem') {

--- a/app/components/Add.js
+++ b/app/components/Add.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useUser } from '../context/UserContext';
 import { View, Text, TextInput, StyleSheet, TouchableOpacity, TouchableWithoutFeedback, Keyboard, ActivityIndicator, FlatList, Alert } from 'react-native';
 import { Image } from 'expo-image';
@@ -760,10 +760,17 @@ const Add = ({ route, navigation }) => {
 
   const onContinuePress = () => {
     const wasRerank = !!rerankItemKey;
+    const categoryId = newItemCategory;
+    const categoryName = newItemCategoryName;
+    const categoryNumItems = numItems;
     resetToDefaultAddState();
     getUserCategories();
     if (wasRerank) {
-      navigation.goBack();
+      navigation.navigate('Profile', {
+        openCategoryId: categoryId,
+        openCategoryName: categoryName,
+        openNumItems: categoryNumItems,
+      });
     }
   }
 
@@ -993,7 +1000,18 @@ const Add = ({ route, navigation }) => {
             <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
               <Text style={{ marginTop: 5, fontWeight: 'bold', fontSize: 20 }}>{newItemCategoryName}</Text>
               <TouchableOpacity onPress={() => {
-                resetToDefaultAddState()
+                const wasRerank = !!rerankItemKey;
+                const categoryId = newItemCategory;
+                const categoryName = newItemCategoryName;
+                const categoryNumItems = numItems;
+                resetToDefaultAddState();
+                if (wasRerank) {
+                  navigation.navigate('Profile', {
+                    openCategoryId: categoryId,
+                    openCategoryName: categoryName,
+                    openNumItems: categoryNumItems,
+                  });
+                }
               }}>
                 <View style={{ backgroundColor: 'lightgrey', padding: 8, fontSize: 13, borderRadius: 10 }}>
                   <Text style={{ fontWeight: 'bold' }}>Back</Text>

--- a/app/components/CategoryList.js
+++ b/app/components/CategoryList.js
@@ -219,6 +219,7 @@ const CategoryList = ({ focusedCategory, focusedList, onBackPress, focusedCatego
     return similarBucketItems;
   }
 
+
   const deleteImageFromStorage = async (imageUri) => {
     try {
       const storage = getStorage();
@@ -342,12 +343,17 @@ const CategoryList = ({ focusedCategory, focusedList, onBackPress, focusedCatego
               </View>
             </View>
             { !editMode && (
-              <View>
+              <View style={{ alignItems: 'center' }}>
                 <View style={[styles.listTileScore, { borderColor: scoreColor, marginLeft: 'auto' }]}>
                   <Text style={{ color: scoreColor, fontWeight: 'bold' }}>{item.score < 0 ? '...' : item.score.toFixed(1)}</Text>
                 </View>
+                { isMyProfile && (
+                  <TouchableOpacity onPress={() => onRerankItemFromList(item, item_key)}>
+                    <Text style={{ fontSize: 11, color: 'gray', marginTop: 4 }}>Rerank</Text>
+                  </TouchableOpacity>
+                )}
                 { visitingUserId !== userKey && itemsInCategory && itemsInCategory.has(item.image) && categoryInfo.category_type !== "" && (
-                  <MaterialIcons name="playlist-add-check-circle" size={20} color="gray" style={{ marginLeft: 'auto', marginTop: 'auto' }} /> 
+                  <MaterialIcons name="playlist-add-check-circle" size={20} color="gray" style={{ marginLeft: 'auto', marginTop: 'auto' }} />
                 )}
               </View>
             )}
@@ -567,6 +573,23 @@ const CategoryList = ({ focusedCategory, focusedList, onBackPress, focusedCatego
       taggedUser: null,
       presetImage: categoryInfo.presetImage
     })
+  }
+
+  const onRerankItemFromList = (item, item_key) => {
+    navigation.navigate('Add', {
+      itemName: item.content,
+      itemDescription: item.description,
+      itemImage: [item.image],
+      itemCategory: item.category_id,
+      itemCategoryName: item.category_name,
+      trackUri: item.trackUri,
+      itemId: item.id,
+      itemContentDescription: item.contentDescription,
+      numItems: numItems,
+      rerankItemKey: item_key,
+      taggedUser: null,
+      presetImage: categoryInfo.presetImage
+    });
   }
 
   const ESTIMATED_ITEM_HEIGHT = 550;

--- a/app/components/CategoryList.js
+++ b/app/components/CategoryList.js
@@ -652,7 +652,7 @@ const CategoryList = ({ focusedCategory, focusedList, onBackPress, focusedCatego
             }, 100);
           }}
           ItemSeparatorComponent={() => <View style={{ height: 1, backgroundColor: '#e0e0e0' }} />}
-          windowSize={5}
+          windowSize={21}
           maxToRenderPerBatch={3}
           initialNumToRender={3}
           removeClippedSubviews={true}

--- a/app/components/Feed.js
+++ b/app/components/Feed.js
@@ -629,7 +629,7 @@ const Feed = ({ route, navigation }) => {
           keyExtractor={keyExtractor}
           removeClippedSubviews={true}
           maxToRenderPerBatch={10}
-          windowSize={5}
+          windowSize={21}
           initialNumToRender={10}
           numColumns={1}
           key={"single-column"}

--- a/app/components/Profile.js
+++ b/app/components/Profile.js
@@ -139,6 +139,13 @@ const Profile = ({ route, navigation }) => {
     }
   }, [profileInfo?.profile_pic]);
 
+  useEffect(() => {
+    const { openCategoryId, openCategoryName, openNumItems } = route.params || {};
+    if (!openCategoryId) return;
+    onCategoryPress(openCategoryName, openCategoryId, openNumItems || 0);
+    navigation.setParams({ openCategoryId: undefined, openCategoryName: undefined, openNumItems: undefined });
+  }, [route.params?.openCategoryId]);
+
   const onCategoryPress = (category_name, category_id, num_items) => {
     const requestId = ++categoryRequestRef.current;
 

--- a/app/components/Profile.js
+++ b/app/components/Profile.js
@@ -492,7 +492,7 @@ const Profile = ({ route, navigation }) => {
                 refreshProfile();
               }
             }}
-            scrollEventThrottle={1} // This ensures the scroll position is updated frequently
+            scrollEventThrottle={16}
           >
             {!visitingUserId ? (
               <View style={{ flexDirection: 'row', marginTop: 10, alignItems: 'center', width: '100%', paddingHorizontal: 20 }}>


### PR DESCRIPTION
## Summary
- Adds a "Rerank" button under the score badge on each item row in your own category list (`CategoryList.js`)
- Tapping it launches the existing ranking flow in the Add screen with that item pre-loaded
- Fixes navigation so that tapping Continue after reranking goes back to the category list instead of staying on the Add tab

## Test plan
- [ ] Open one of your own category lists — each entry should show a small "Rerank" label under the score badge
- [ ] Tap "Rerank" on any entry — ranking screen opens with that item
- [ ] Complete the ranking — tap Continue — should return to the category list with updated score
- [ ] Viewing someone else's list — "Rerank" label should not appear
- [ ] Normal item adds (not rerankings) — Continue still stays on Add tab as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)