### PR TITLE
feat: accurate item navigation when clicking on a list, better ui for editing and reranking items, and updated too tough functionality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 # CLAUDE.md
-Please understand that my primary focus in coding is to learn, and please teach every single code you spit out to me to me as if I'm someone who's never seen a line of code in their life.
+Please understand that my primary focus in coding is to learn, and please teach every single code you spit out to me to me as if I'm someone who's never seen a line of code in their life. Start from a high level equating what happens to the physical components on the screen if possible, and then work your way down to how the code understands information.
 
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.

--- a/app/components/Add.js
+++ b/app/components/Add.js
@@ -121,6 +121,7 @@ const Add = ({ route, navigation }) => {
 
   const [binarySearchM, setBinarySearchM] = useState(0);
   const [newItemFinalScore, setNewItemFinalScore] = useState(-1);
+  const tooToughKeysRef = useRef(new Set());
   const [loaded] = useFonts({
     'Poppins Regular': require('../../assets/fonts/Poppins-Regular.ttf'), 
     'Poppins Bold': require('../../assets/fonts/Poppins-Bold.ttf'),
@@ -339,7 +340,7 @@ const Add = ({ route, navigation }) => {
 
   // update 4 here ***
   // I've had errors where some fields in the database don't have a field causing an error that is not logged
-  const addNewItem = async (newItemBucket, newBinarySearchM, isNewCard, dupKey) => {
+  const addNewItem = async (newItemBucket, newBinarySearchM, isNewCard, dupKey, tieOverride) => {
     setRankMode(false);
     setAddView('addingItem');
     if (newItemImageUris.length > 0 && addedCustomImage) {
@@ -367,7 +368,15 @@ const Add = ({ route, navigation }) => {
       };
       // make sure any changes to newItemObj are also reflected in itemComparisons
       let newKey = null;
-      let items = addElementAndRecalculate(itemComparisons, newItemObj, newBinarySearchM, isNewCard);
+      let items;
+      if (tieOverride?.tieWithScore !== undefined) {
+        newItemObj.score = tieOverride.tieWithScore;
+        const insertAt = isNewCard ? newBinarySearchM : newBinarySearchM + 1;
+        itemComparisons.splice(insertAt, 0, newItemObj);
+        items = itemComparisons;
+      } else {
+        items = addElementAndRecalculate(itemComparisons, newItemObj, newBinarySearchM, isNewCard);
+      }
       for (let i = 0; i < items.length; i++) {
         const item = items[i];
         let itemRef = null;
@@ -421,6 +430,7 @@ const Add = ({ route, navigation }) => {
         set(eventsRef, { evokerId: userKey, content: 'tagged you in a post: ' + newItem + '!', timestamp: Date.now(), postId: newKey });
         update(ref(database, 'users/' + taggedUser.userId), { unreadNotifications: true });
       }
+      tooToughKeysRef.current = new Set();
       setAddView('itemAdded'); // ~ do we need this?
     } else {
       const newItemObj = {
@@ -439,7 +449,15 @@ const Add = ({ route, navigation }) => {
       };
       // make sure any changes to newItemObj are also reflected in itemComparisons
       let newKey = null;
-      let items = addElementAndRecalculate(itemComparisons, newItemObj, newBinarySearchM, isNewCard);
+      let items;
+      if (tieOverride?.tieWithScore !== undefined) {
+        newItemObj.score = tieOverride.tieWithScore;
+        const insertAt = isNewCard ? newBinarySearchM : newBinarySearchM + 1;
+        itemComparisons.splice(insertAt, 0, newItemObj);
+        items = itemComparisons;
+      } else {
+        items = addElementAndRecalculate(itemComparisons, newItemObj, newBinarySearchM, isNewCard);
+      }
       for (let i = 0; i < items.length; i++) {
         const item = items[i];
         let itemRef = null;
@@ -492,6 +510,7 @@ const Add = ({ route, navigation }) => {
         set(eventsRef, { evokerId: userKey, content: 'tagged you in a post: ' + newItem + '!', timestamp: Date.now(), postId: newKey, image: newItemImageUris[0] || null });
         update(ref(database, 'users/' + taggedUser.userId), { unreadNotifications: true });
       }
+      tooToughKeysRef.current = new Set();
       setAddView('itemAdded');
     }
 
@@ -590,6 +609,7 @@ const Add = ({ route, navigation }) => {
       } 
       setItemComparisons(itemComparisons)
       setNewItemBucket(bucket); // bucket doesn't update fast enough so need to pass in as a parameter
+      tooToughKeysRef.current = new Set();
       setBinarySearchL(0);
       setBinarySearchR(itemComparisons.length - 1);
       setBinarySearchM(Math.floor((itemComparisons.length - 1) / 2));
@@ -631,6 +651,19 @@ const Add = ({ route, navigation }) => {
   }
 
   const onTooToughPress = () => {
+    const currentCompareItem = itemComparisons[binarySearchM];
+    const currentKey = currentCompareItem?.key;
+
+    if (currentKey && tooToughKeysRef.current.has(currentKey)) {
+      setBinarySearchL(0);
+      setBinarySearchR(0);
+      addNewItem(newItemBucket, binarySearchM, true, undefined, { tieWithScore: currentCompareItem.score });
+      return;
+    }
+
+    if (currentKey) {
+      tooToughKeysRef.current.add(currentKey);
+    }
     setBinarySearchM(prev => prev + 1);
     if (binarySearchM >= binarySearchR) {
       setBinarySearchL(0);

--- a/app/components/CategoryList.js
+++ b/app/components/CategoryList.js
@@ -62,9 +62,10 @@ const CategoryList = ({ focusedCategory, focusedList, onBackPress, focusedCatego
   const [categoryListView, setCategoryListView] = useState(null);
   const [listBackButtonKey, setListBackButtonKey] = useState(0);
   const [isListBackPressing, setIsListBackPressing] = useState(false);
-  const [focusedItemIndex, setFocusedItemIndex] = useState(null);
+  const [focusedItemKey, setFocusedItemKey] = useState(null);
   const [scrollViewMode, setScrollViewMode] = useState(false);
   const flatListRef = useRef(null);
+  const itemHeightsRef = useRef({});
 
   // Keep local editable list data in sync with parent updates before paint to avoid empty-state flicker.
   useLayoutEffect(() => {
@@ -189,16 +190,19 @@ const CategoryList = ({ focusedCategory, focusedList, onBackPress, focusedCatego
   }, [focusedItem, categoryListView, profileView]);
 
   useEffect(() => {
-    if (scrollViewMode && focusedItemIndex !== null) {
-      setTimeout(() => {
-        flatListRef.current?.scrollToIndex({
-          index: focusedItemIndex,
-          animated: false,
-          viewPosition: 0.1,
-        });
-      }, 100);
+    if (scrollViewMode && focusedItemKey !== null) {
+      const scrollToFocused = () => {
+        const idx = listData[listView].findIndex(([k]) => k === focusedItemKey);
+        if (idx < 0) return;
+        const itemsAbove = listData[listView].slice(0, idx);
+        const itemsHeight = itemsAbove.reduce((sum, [k]) => sum + (itemHeightsRef.current[k] ?? 0), 0);
+        const separatorsHeight = itemsAbove.length;
+        flatListRef.current?.scrollToOffset({ offset: itemsHeight + separatorsHeight, animated: false });
+      };
+      setTimeout(scrollToFocused, 250);
+      setTimeout(scrollToFocused, 700);
     }
-  }, [scrollViewMode, focusedItemIndex]);
+  }, [scrollViewMode, focusedItemKey]);
 
   function recalculateItems(similarBucketItems, item_bucket) {
     const minMaxMap = {
@@ -301,7 +305,7 @@ const CategoryList = ({ focusedCategory, focusedList, onBackPress, focusedCatego
   }
 
   const onItemPress = (item_key, index) => {
-    setFocusedItemIndex(index);
+    setFocusedItemKey(item_key);
     setScrollViewMode(true);
   }
 
@@ -348,8 +352,8 @@ const CategoryList = ({ focusedCategory, focusedList, onBackPress, focusedCatego
                   <Text style={{ color: scoreColor, fontWeight: 'bold' }}>{item.score < 0 ? '...' : item.score.toFixed(1)}</Text>
                 </View>
                 { isMyProfile && (
-                  <TouchableOpacity onPress={() => onRerankItemFromList(item, item_key)}>
-                    <Text style={{ fontSize: 11, color: 'gray', marginTop: 4 }}>Rerank</Text>
+                  <TouchableOpacity onPress={() => onListItemMenuPress(item, item_key)} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+                    <Ionicons name="ellipsis-horizontal" size={16} color="gray" style={{ marginTop: 4 }} />
                   </TouchableOpacity>
                 )}
                 { visitingUserId !== userKey && itemsInCategory && itemsInCategory.has(item.image) && categoryInfo.category_type !== "" && (
@@ -546,6 +550,18 @@ const CategoryList = ({ focusedCategory, focusedList, onBackPress, focusedCatego
     );
   };
 
+  const onFocusedItemMenuPress = () => {
+    Alert.alert(
+      "Item options",
+      "",
+      [
+        { text: "Rerank", onPress: () => onRerankItemPress() },
+        { text: "Edit", onPress: () => onEditPress() },
+        { text: "Cancel", style: "cancel" },
+      ]
+    );
+  };
+
   const pickImage = async () => {
     let result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ImagePicker.MediaTypeOptions.All,
@@ -592,29 +608,21 @@ const CategoryList = ({ focusedCategory, focusedList, onBackPress, focusedCatego
     });
   }
 
-  const ESTIMATED_ITEM_HEIGHT = 550;
-
-  const getItemLayout = (data, index) => ({
-    length: ESTIMATED_ITEM_HEIGHT,
-    offset: ESTIMATED_ITEM_HEIGHT * index,
-    index,
-  });
-
-  const renderScrollableItem = ({ item: [item_key, item], index }) => {
-    const itemWithKey = { ...item, key: item_key };
-
-    return (
-      <NormalItemTile
-        item={itemWithKey}
-        visitingUserId={visitingUserId}
-        navigation={navigation}
-        showComments={false}
-        setFeedView={setProfileView}
-        userKey={userKey}
-        isMyProfile={isMyProfile}
-      />
+  const onListItemMenuPress = (item, item_key) => {
+    Alert.alert(
+      "Item options",
+      "",
+      [
+        { text: "Rerank", onPress: () => onRerankItemFromList(item, item_key) },
+        { text: "Edit", onPress: () => {
+          setFocusedItem({ ...item, key: item_key });
+          setFocusedItemDescription(item.description ?? '');
+          setEditMode(true);
+        } },
+        { text: "Cancel", style: "cancel" },
+      ]
     );
-  };
+  }
 
   const memoizedList = useMemo(() => {
     if (!shouldRenderList) return [];
@@ -647,12 +655,16 @@ const CategoryList = ({ focusedCategory, focusedList, onBackPress, focusedCatego
   }
 
   if (scrollViewMode) {
+    const focusedIndex = focusedItemKey
+      ? listData[listView].findIndex(([k]) => k === focusedItemKey)
+      : -1;
     return (
       <View style={{ flex: 1, backgroundColor: 'white' }}>
         <View style={{ flexDirection: 'row', padding: 10, borderBottomWidth: 1, borderColor: 'lightgrey', alignItems: 'center' }}>
           <TouchableOpacity onPress={() => {
             setScrollViewMode(false);
-            setFocusedItemIndex(null);
+            setFocusedItemKey(null);
+            itemHeightsRef.current = {};
           }}>
             <Ionicons name="arrow-back" size={30} color="black" />
           </TouchableOpacity>
@@ -665,20 +677,30 @@ const CategoryList = ({ focusedCategory, focusedList, onBackPress, focusedCatego
         <FlatList
           ref={flatListRef}
           data={listData[listView]}
-          renderItem={renderScrollableItem}
-          keyExtractor={([item_key, item]) => item_key}
-          initialScrollIndex={focusedItemIndex}
-          getItemLayout={getItemLayout}
-          onScrollToIndexFailed={(info) => {
-            setTimeout(() => {
-              flatListRef.current?.scrollToIndex({ index: info.index, animated: false });
-            }, 100);
+          keyExtractor={([k]) => k}
+          initialNumToRender={listData[listView].length}
+          renderItem={({ item: [item_key, item], index }) => {
+            const distance = focusedIndex === -1 ? Infinity : Math.abs(index - focusedIndex);
+            const priority = distance <= 5 ? 'high' : 'low';
+            return (
+              <View onLayout={(e) => { itemHeightsRef.current[item_key] = e.nativeEvent.layout.height; }}>
+                <NormalItemTile
+                  item={{ ...item, key: item_key }}
+                  visitingUserId={visitingUserId}
+                  navigation={navigation}
+                  showComments={false}
+                  setFeedView={setProfileView}
+                  userKey={userKey}
+                  isMyProfile={isMyProfile}
+                  imagePriority={priority}
+                />
+              </View>
+            );
           }}
           ItemSeparatorComponent={() => <View style={{ height: 1, backgroundColor: '#e0e0e0' }} />}
           windowSize={21}
-          maxToRenderPerBatch={3}
-          initialNumToRender={3}
-          removeClippedSubviews={true}
+          maxToRenderPerBatch={2}
+          removeClippedSubviews={false}
         />
       </View>
     );
@@ -714,14 +736,9 @@ const CategoryList = ({ focusedCategory, focusedList, onBackPress, focusedCatego
             <Text style={{ fontSize: 15, fontWeight: 'bold' }}>Done</Text>
           </TouchableOpacity>
         ) : isMyProfile ? (
-          <View style={{ flexDirection: 'row' }}>
-          <TouchableOpacity onPress={() => onRerankItemPress()}>
-            <Text style={{ fontSize: 15, marginRight: 30 }}>Rerank</Text>
-          </TouchableOpacity>
-          <TouchableOpacity onPress={() => onEditPress()}>
+          <TouchableOpacity onPress={() => onFocusedItemMenuPress()}>
             <Ionicons name="ellipsis-horizontal" size={22} color="black" />
           </TouchableOpacity>
-          </View>
         ) : (
           <Text>       </Text>
         )}

--- a/app/components/NormalItemTile.js
+++ b/app/components/NormalItemTile.js
@@ -94,13 +94,14 @@ const styles = StyleSheet.create({
 const arePropsEqual = (prevProps, nextProps) =>
   prevProps.item.key === nextProps.item.key &&
   prevProps.item.score === nextProps.item.score &&
-  prevProps.topPostsTime === nextProps.topPostsTime;
+  prevProps.topPostsTime === nextProps.topPostsTime &&
+  prevProps.imagePriority === nextProps.imagePriority;
 
-const NormalItemTile = React.memo(({ item, showButtons=true, userKey, setFeedView, navigation, visitingUserId, editMode=false, setFocusedItemDescription, topPostsTime, setItemInfo, showComments=false, individualSpotifyAccessToken, promptAsync, setIndex, onBlockUser, onReportItem }) => {
+const NormalItemTile = React.memo(({ item, showButtons=true, userKey, setFeedView, navigation, visitingUserId, editMode=false, setFocusedItemDescription, topPostsTime, setItemInfo, showComments=false, individualSpotifyAccessToken, promptAsync, setIndex, onBlockUser, onReportItem, imagePriority='normal' }) => {
   const userRef = ref(database, `users/${item.user_id}`);
   const [username, setUsername] = useState('');
   const [userImage, setUserImage] = useState('https://www.prolandscapermagazine.com/wp-content/uploads/2022/05/blank-profile-photo.png');
-  const [dimensions, setDimensions] = useState({ width: undefined, height: undefined });
+  const [dimensions, setDimensions] = useState({ width: 260, height: 260 });
   const [itemDescription, setItemDescription] = useState(item.description);
   const [likes, setLikes] = useState({});
   const [dislikes, setDislikes] = useState({});
@@ -816,6 +817,10 @@ const NormalItemTile = React.memo(({ item, showButtons=true, userKey, setFeedVie
                     style={{ width: 260, height: 260, borderRadius: 5, borderWidth: 0.5, borderColor: 'lightgrey' }}
                     contentFit="cover"
                     cachePolicy="memory-and-disk"
+                    placeholder={{ blurhash: 'L6PZfSjE.AyE_3t7t7R**0o#DgR4' }}
+                    transition={200}
+                    recyclingKey={`${item.key}-${imgUri}`}
+                    priority={imagePriority}
                   />
                 )}
               />
@@ -848,6 +853,10 @@ const NormalItemTile = React.memo(({ item, showButtons=true, userKey, setFeedVie
               }}
               onLoad={onImageLoad}
               cachePolicy="memory-and-disk"
+              placeholder={{ blurhash: 'L6PZfSjE.AyE_3t7t7R**0o#DgR4' }}
+              transition={200}
+              recyclingKey={item.key}
+              priority={imagePriority}
             />
           )}
           </>


### PR DESCRIPTION
## Summary
- Replaced per-row "Rerank" text button with an ellipsis menu containing Rerank + Edit options. Edit now correctly opens the focused-item screen with the description ready to inline-edit.
- Consolidated the focused-item header actions into a single ellipsis menu with Rerank + Edit.
- Updated "Too Tough" ranking behavior: a second "Too Tough" press against the same item during one ranking session now ties the new item's score to that item's score and ends the flow (instead of continuing the binary search).
- Bundled image-loading improvements on `NormalItemTile` (blurhash placeholder, transition, recycling key, priority) to reduce flicker while scrolling.

## Test plan
- [ ] Tap the "..." next to a row in your own list → confirm Rerank and Edit options both appear.
- [ ] Choose Edit → confirm you land on the item detail screen with the description as an editable text input, and Done saves back to Firebase.
- [ ] Choose Rerank → confirm rerank flow starts against the correct item.
- [ ] Rank a new item and hit "Too Tough" once against item B, then again against a different item C → confirm normal binary-search behavior.
- [ ] Rank a new item and hit "Too Tough" against item B, keep going, then when B comes back up hit "Too Tough" again → confirm the flow ends and the new item's score equals B's exactly (B's score is unchanged).
- [ ] Scroll a long list with images → confirm no visual regressions vs. before.